### PR TITLE
Problem: email has hardcoded endpoint

### DIFF
--- a/email/email.c
+++ b/email/email.c
@@ -1,9 +1,17 @@
 #include <czmq.h>
 #include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 int main(int argc, char** argv) {
 
-    zsock_t *client = zsock_new_sub("tcp://*:5561", "");
+    char *endpoint = "tcp://*:5561";
+    if (argc <= 1)
+        zsys_info("You can use email-cli tcp://ip-address:5561\n");
+    else
+        endpoint = argv[1];
+
+    zsock_t *client = zsock_new_sub(endpoint, "");
     assert (client);
 
     char *msg, *ups, *state;


### PR DESCRIPTION
Solution: have \* as default, allow to specify own one on commandline
