### PR TITLE
Jim: enhanced Makefile rules to compile ups.cxx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 email-cli
 monitor-cli
 ups-cli
+ups-cli++
 

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,12 @@ $(PROGRAM_EMAIL): email/email.c
 $(PROGRAM_UPS): ups/ups.c
 	$(CC) $(CFLAGS) -o $@ $^
 
-# Requires https://github.com/zeromq/cppzmq/raw/master/zmq.hpp
 $(PROGRAM_UPSXX): ups/ups.cxx
-	$(CXX) $(CXXFLAGS) -o $@ $^
+	@echo "$(CXX) $(CXXFLAGS) -o $@ $^"; \
+	if $(CXX) $(CXXFLAGS) -o $@ $^; then : ; else RES=$$?; \
+	    echo "NOTE: ups.cxx requires zmq.hpp available at https://github.com/zeromq/cppzmq/raw/master/zmq.hpp" >&2; \
+	    exit $$RES; \
+	fi
 
 $(PROGRAM_MON): monitor/monitor.cc
 	$(CXX) $(CXXFLAGS) -o $@ $^


### PR DESCRIPTION
Problems solved:
- Compilation of `ups-cli++` can end up in an error due to missing `zmq.hpp` which is no longer packaged by debian; suggest on build console where to get a copy
- `ups-cli++` shows up in `git status`
