### PR TITLE
Problem: monitor node name is hardcoded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 	$(RM) -f $(PROGRAMS)
 
 $(PROGRAM_EMAIL): email/email.c
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -lzyre -o $@ $^
 
 $(PROGRAM_UPS): ups/ups.c
 	$(CC) $(CFLAGS) -o $@ $^

--- a/monitor/monitor.cc
+++ b/monitor/monitor.cc
@@ -22,7 +22,7 @@ int main (int argc, char **argv) {
     zsock_set_subscribe (sub, "");
 
     zsock_t *pub = zsock_new (ZMQ_PUB);
-    assert (pub); 
+    assert (pub);
     rv = zsock_bind (pub, "tcp://*:5561");
     assert (rv != -1);
 


### PR DESCRIPTION
Solution: use autodiscovery using zyre
